### PR TITLE
dev 1.1.0 // Change log output for merge from external keystore

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Zero-Touch Provisioning system built for Cisco Catalyst switches.
 
 -----------------------------------------
 ##   VERSION   ##
-The version of FreeZTP documented here is: **v1.1.0**
+The version of FreeZTP documented here is: **dev1.1.0l**
 
 
 -----------------------------------------
@@ -504,7 +504,7 @@ FreeZTP v1.1.0 introduced the concept of external keystores. An external keystor
   - `association` (Optional) - This header/column specifies which template will be used when the Keystore ID is matched. If it is left blank, FreeZTP will use the default template
   - `idarray_xxx` (Optional) - Any header beginning with `idarray` will add the values in that column into an IDArray for the `keystore_id` specified in its row.
 
-The easiest way to get started with external keystores is to use an example CSV file. Use the command `ztp request keystore-csv-export <file_name>` to generate one out of your current Keystore, IDArray, and Association data. You can then configure the external keystore; an example is provided below. 
+The easiest way to get started with external keystores is to use an example CSV file. Use the command `ztp request keystore-csv-export <file_name>` to generate one out of your current Keystore, IDArray, and Association data. You can then configure the external keystore; an example is provided below.
 
 ```
 ztp set external-keystore MYCSVFILE type csv
@@ -534,13 +534,23 @@ Once setup, you can send a test message to the integration destination using the
 -----------------------------------------
 ##   VERSIONS   ##
 
+### v1.0.1
 **Bug Fixes in V1.0.0 --> V1.0.1:**
 - *ISSUE #20*: The command `ztp show ztp dhcpd leases` would throw an exception is the `uid` key is not present in the DHCP lease reader.
 
 
+### v1.1.0
+**Bug Fixes in V1.0.0 --> V1.1.0:**
+- *ISSUE #27*: The command `ztp request external-keystore-test` shows some extraneous data at the top. Removed an unneeded print statement.
+- *ISSUE #32*: The command `ztp show provisioning` would show epoch time. Now it will show local time.
+
 **Added Features in V1.0.1 --> V1.1.0:**
-- *External Keystores*: A respository of FreeZTP Keystore, IDArray, and Association data which can be stored and accessed from an external data source. See the [External Keystores](#external-keystores) section for more information.
+- *External Keystores*: A repository of FreeZTP Keystore, IDArray, and Association data which can be stored and accessed from an external data source. See the [External Keystores](#external-keystores) section for more information.
+- *External Templates*: Jinja2 templates can now be saved as files and referenced from the FreeZTP config in the form of `set external-template <template_name> file <filepath>`. External-templates are loaded when the ZTP service is started and kept in memory. The service must be restarted for any file changes to take effect
 - *Integrations*: 3rd party hooks which can be leveraged for notifications, etc. See the [Integrations](#integrations) section for more information.
+- *IDArray Values for Merging*: You can now insert IDArray values into your templates one of two ways (seen below). You can now also see the list of values available for merging in a log message right before the merge happens (use `ztp request merge-test` to test and see this).
+  - Using the variables `{{ idarray_1 }}`, `{{ idarray_2 }}`, etc... will present the string values of the idarray entries for Jinja2 merging
+  - Using the variable `{{ idarray }}` will present a list of IDArray values to the Jinja2 merge
 
 
 -----------------------------------------

--- a/ztp.py
+++ b/ztp.py
@@ -382,7 +382,7 @@ class config_factory:
 						mcfg = open(("/srv/ztp/tftproot/merged/" + identity + "_" + templatename + ".cfg"), "w") #This location should be configurable.
 						mcfg.write(result)
 						mcfg.close()
-						log("cfact.request: Final config merged, saved and returned to TFTPy:\n%s\n# ID: %s\n# Template: %s\n# File: %s\n%s" % ("#"*25, identity, templatename, mcfg.name, "#"*25))
+						log("cfact.request: Final config merged, saved, and returned to TFTPy:\n%s\n# ID: %s\n# Template: %s\n# File: %s\n%s" % ("#"*50, identity, templatename, mcfg.name, "#"*50))
 						self.send_tracking_update(ipaddr, filename, len(result))
 						if not test:
 							tracking.provision({

--- a/ztp.py
+++ b/ztp.py
@@ -379,7 +379,10 @@ class config_factory:
 					log("cfact.request: Keystore ID Lookup returned (%s)" % keystoreid)
 					if keystoreid:
 						result = self.merge_final_config(keystoreid)
-						log("#"*25, "\n\n\ncfact.request: Sending config for (%s) using template (%s) to TFTPy.\n\n\n" % (identity, templatename), "#"*25)
+						mcfg = open(("/srv/ztp/tftproot/merged/" + identity + "_" + templatename + ".cfg"), "w") #This location should be configurable.
+						mcfg.write(result)
+						mcfg.close()
+						log("cfact.request: Final config merged, saved and returned to TFTPy:\n%s\n# ID: %s\n# Template: %s\n# File: %s\n%s" % ("#"*25, identity, templatename, mcfg.name, "#"*25))
 						self.send_tracking_update(ipaddr, filename, len(result))
 						if not test:
 							tracking.provision({

--- a/ztp.py
+++ b/ztp.py
@@ -379,7 +379,7 @@ class config_factory:
 					log("cfact.request: Keystore ID Lookup returned (%s)" % keystoreid)
 					if keystoreid:
 						result = self.merge_final_config(keystoreid)
-						log("cfact.request: Returning the below config to TFTPy:\n%s\n%s\n%s" % ("#"*25, result, "#"*25))
+						log("#"*25, "\n\n\ncfact.request: Sending config for (%s) using template (%s) to TFTPy.\n\n\n" % (identity, templatename), "#"*25)
 						self.send_tracking_update(ipaddr, filename, len(result))
 						if not test:
 							tracking.provision({

--- a/ztp.py
+++ b/ztp.py
@@ -379,7 +379,7 @@ class config_factory:
 					log("cfact.request: Keystore ID Lookup returned (%s)" % keystoreid)
 					if keystoreid:
 						result = self.merge_final_config(keystoreid)
-						mcfg = open(("/srv/ztp/tftproot/merged/" + identity + "_" + templatename + ".cfg"), "w") #This location should be configurable.
+						mcfg = open("/srv/ztp/tftproot/merged/%s_%s.cfg" % (identity, templatename), "w") #This location should be configurable.
 						mcfg.write(result)
 						mcfg.close()
 						log("cfact.request: Final config merged, saved, and returned to TFTPy:\n%s\n# ID: %s\n# Template: %s\n# File: %s\n%s" % ("#"*50, identity, templatename, mcfg.name, "#"*50))


### PR DESCRIPTION
### Goals
* Avoid outputting the configuration to the log file in plain text.
* Still have a 'chunky' log message for the successful merge to an external keystore and template association.

### Concerns
* Will the `identity` and `templatename` variables pass through from `def get_template`?